### PR TITLE
can not register the vue-select component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 lib
+package-lock.json
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^13.3.0",
+    "@types/vue-select": "^3.16.2",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
     "@vue/compiler-sfc": "^3.2.38",
@@ -31,6 +32,7 @@
     "vue": "^3.2.38"
   },
   "dependencies": {
-    "vue": "^3.2.38"
+    "vue": "^3.2.38",
+    "vue-select": "^4.0.0-beta.5"
   }
 }

--- a/src/DropDownInputControl/DropDownInputControl.vue
+++ b/src/DropDownInputControl/DropDownInputControl.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type * as Rete from "rete";
+import type { EventsTypes } from "rete/types/events";
+import { defineComponent } from "vue";
+import vSelect from "vue-select";
+// import "vue-select/dist/vue-select.css";
+// Vue.component("v-select", vSelect);
+
+
+export interface Props {
+  initialValue: string;
+  ikey: string;
+  reteEmitter?: Rete.Emitter<EventsTypes> | undefined;
+  reteGetData?: (ikey: string) => number;
+  retePutData?: (ikey: string, value: number) => void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  reteGetData: (ikey: string) => 0,
+  retePutData: (ikey: string, value: number) => {
+    return;
+  },
+  reteEmitter: undefined,
+
+});
+
+const emits = defineEmits([]);
+</script>
+
+<script lang="ts">
+export default defineComponent({
+  data() {
+    return {
+      currentValue: this.initialValue === undefined ? 0 : this.initialValue,
+      dimensions: ["x_dimension", "y_dimension", "z_dimension"],
+    };
+  },
+  methods: {
+    change(e: Event) {
+      this.currentValue = +(e.target as HTMLInputElement).value;
+      this.update();
+    },
+    update() {
+      if (this.ikey) {
+        this.retePutData?.(this.ikey, this.currentValue);
+      }
+      this.reteEmitter?.trigger("process");
+    },
+    mounted() {
+      this.currentValue = "";
+      if (this.ikey && this.reteGetData)
+        this.currentValue = this.reteGetData(this.ikey);
+    },
+  },
+});
+</script>
+
+<template>
+  <v-select :options="dimensions" />
+</template>

--- a/src/TextInputControl/TextInputControl.vue
+++ b/src/TextInputControl/TextInputControl.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type * as Rete from "rete";
+import type { EventsTypes } from "rete/types/events";
+import { defineComponent } from "vue";
+
+export interface Props {
+  initialValue: string;
+  ikey: string;
+  reteEmitter?: Rete.Emitter<EventsTypes> | undefined;
+  reteGetData?: (ikey: string) => number;
+  retePutData?: (ikey: string, value: number) => void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  reteGetData: (ikey: string) => 0,
+  retePutData: (ikey: string, value: number) => {
+    return;
+  },
+  reteEmitter: undefined,
+});
+
+const emits = defineEmits([]);
+</script>
+
+<script lang="ts">
+export default defineComponent({
+  data() {
+    return {
+      currentValue: this.initialValue === undefined ? 0 : this.initialValue,
+    };
+  },
+  methods: {
+    change(e: Event) {
+      this.currentValue = +(e.target as HTMLInputElement).value;
+      this.update();
+    },
+    update() {
+      if (this.ikey) {
+        this.retePutData?.(this.ikey, this.currentValue);
+      }
+      this.reteEmitter?.trigger("process");
+    },
+    mounted() {
+      this.currentValue = "";
+      if (this.ikey && this.reteGetData)
+        this.currentValue = this.reteGetData(this.ikey);
+    },
+  },
+});
+</script>
+<template>
+  <input type="string" @input="change($event)" @mousedown.stop />
+</template>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
-import NumberInputControl from "./NumberInputControl/NumberInputControl.vue"
-
+import NumberInputControl from "./NumberInputControl/NumberInputControl.vue";
+import TextInputControl from "./TextInputControl/TextInputControl.vue";
+import DropDownInputControl from "./DropDownInputControl/DropDownInputControl.vue";
 export { NumberInputControl };
+export { DropDownInputControl };
+export { TextInputControl };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
-
-  {
+{
   "extends": "@vue/tsconfig/tsconfig.web.json",
   "compilerOptions": {
     "jsx": "preserve",
@@ -12,10 +11,14 @@
     "importHelpers": true,
     "strict": true,
     "experimentalDecorators": true,
+    "allowJs": true,
   },
-    "typeRoots": [
-      "./node_modules/@types/",
-      "./src/localtypes"
-    ],
-  "include": ["src/**/*.ts", "src/**/*.vue"]
+  "typeRoots": [
+    "./node_modules/@types/",
+    "./src/localtypes"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.vue"
+  ]
 }


### PR DESCRIPTION
for dropdown control, we tend to use vue-select, while when trying to register the component 
```
import Vue from 'vue'
import vSelect from 'vue-select'

Vue.component('v-select', vSelect)
```
we will have an error `Default export of the module has or is using private name 'Props'.`

Normally, people will create a js file contains the scripts above. while here we use the composition mode of vue.js and has included the scripts in the `<script setup lang="ts">`part