### PR TITLE
fix npm issues

### DIFF
--- a/src/TextInputControl/TextInputControl.vue
+++ b/src/TextInputControl/TextInputControl.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import { ref, watchEffect } from 'vue';
 import type * as Rete from "rete";
 import type { EventsTypes } from "rete/types/events";
-import { defineComponent } from "vue";
+import { defineProps, withDefaults } from 'vue';
 
-export interface Props {
+interface Props {
   initialValue: string;
   ikey: string;
   reteEmitter?: Rete.Emitter<EventsTypes> | undefined;
@@ -19,35 +20,31 @@ const props = withDefaults(defineProps<Props>(), {
   reteEmitter: undefined,
 });
 
-const emits = defineEmits([]);
+let currentValue = ref(props.initialValue || "")
+
+const change = (e: Event) => {
+  currentValue.value = (e.target as HTMLInputElement).value;
+  update();
+}
+
+const update = () => {
+  if (props.ikey) {
+    props.retePutData?.(props.ikey, Number(currentValue.value));
+  }
+  props.reteEmitter?.trigger("process");
+}
+
+watchEffect(() => {
+  if (props.ikey && props.reteGetData)
+    currentValue.value = props.reteGetData(props.ikey).toString();
+})
 </script>
 
-<script lang="ts">
-export default defineComponent({
-  data() {
-    return {
-      currentValue: this.initialValue === undefined ? 0 : this.initialValue,
-    };
-  },
-  methods: {
-    change(e: Event) {
-      this.currentValue = +(e.target as HTMLInputElement).value;
-      this.update();
-    },
-    update() {
-      if (this.ikey) {
-        this.retePutData?.(this.ikey, this.currentValue);
-      }
-      this.reteEmitter?.trigger("process");
-    },
-    mounted() {
-      this.currentValue = "";
-      if (this.ikey && this.reteGetData)
-        this.currentValue = this.reteGetData(this.ikey);
-    },
-  },
-});
-</script>
 <template>
-  <input type="string" @input="change($event)" @mousedown.stop />
+  <input
+    type="text"
+    @input="change($event)"
+    @mousedown.stop
+    v-model="currentValue"
+  />
 </template>


### PR DESCRIPTION
After using `npm run build`
Here are the errors

```
src/index.ts → lib/index.js, lib/index.esm.js...
[!] (plugin rpt2) Error: src/NumberInputControl/NumberInputControl.vue?vue&type=script&setup=true&lang.ts:43:46 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type '{ __name: string; props: { initialValue: { type: NumberConstructor; required: true; }; ikey: { type: StringConstructor; required: true; }; reteEmitter: { ...; }; reteGetData: { ...; }; retePutData: { ...; }; }; ... 57 more ...; style?: unknown; }' is not assignable to parameter of type 'ComponentOptionsWithObjectProps<{ initialValue: { type: NumberConstructor; required: true; }; ikey: { type: StringConstructor; required: true; }; reteEmitter: { type: null; required: false; default: undefined; }; reteGetData: { ...; }; retePutData: { ...; }; }, ... 12 more ..., { ...; }>'.
      Type '{ __name: string; props: { initialValue: { type: NumberConstructor; required: true; }; ikey: { type: StringConstructor; required: true; }; reteEmitter: { ...; }; reteGetData: { ...; }; retePutData: { ...; }; }; ... 57 more ...; style?: unknown; }' is not assignable to type 'ComponentOptionsBase<{ readonly initialValue: number; readonly ikey: string; readonly reteGetData: Function; readonly retePutData: Function; readonly reteEmitter?: any; }, unknown, { currentValue: number | Function; }, ... 9 more ..., {}>'.
        Types of property '__defaults' are incompatible.
          Type '{} | undefined' is not assignable to type '{ reteEmitter: any; reteGetData: Function; retePutData: Function; } | undefined'.
            Type '{}' is missing the following properties from type '{ reteEmitter: any; reteGetData: Function; retePutData: Function; }': reteEmitter, reteGetData, retePutData

 43 export default /*#__PURE__*/_defineComponent({
                                                 ~
 44   ...__default__,
    ~~~~~~~~~~~~~~~~~
... 
 75 
    
 76 })
    ~

  node_modules/@vue/runtime-core/dist/runtime-core.d.ts:1245:25
    1245 export declare function defineComponent<PropsOptions extends Readonly<ComponentPropsOptions>, RawBindings, D, C extends ComputedOptions = {}, M extends MethodOptions = {}, Mixin extends ComponentOptionsMixin = ComponentOptionsMixin, Extends extends ComponentOptionsMixin = ComponentOptionsMixin, E extends EmitsOptions = {}, EE extends string = string, S extends SlotsType = {}, I extends ComponentInjectOptions = {}, II extends string = string>(options: ComponentOptionsWithObjectProps<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE, I, II, S>): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE, PublicProps, ResolveProps<PropsOptions, E>, ExtractDefaultPropTypes<PropsOptions>, S>;
                                 ~~~~~~~~~~~~~~~
    The last overload is declared here.

src/NumberInputControl/NumberInputControl.vue?vue&type=script&setup=true&lang.ts

    at error (/workspaces/nodeeditor-controls/node_modules/rollup/dist/shared/rollup.js:198:30)
    at throwPluginError (/workspaces/nodeeditor-controls/node_modules/rollup/dist/shared/rollup.js:21718:12)
    at Object.error (/workspaces/nodeeditor-controls/node_modules/rollup/dist/shared/rollup.js:22672:20)
    at Object.error (/workspaces/nodeeditor-controls/node_modules/rollup/dist/shared/rollup.js:21895:42)
    at RollupContext.error (/workspaces/nodeeditor-controls/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:3054:26)
    at /workspaces/nodeeditor-controls/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29423:26
    at Array.forEach (<anonymous>)
    at printDiagnostics (/workspaces/nodeeditor-controls/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29399:17)
    at typecheckFile (/workspaces/nodeeditor-controls/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29571:9)
    at Object.transform (/workspaces/nodeeditor-controls/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29694:17)
```
and the branch aims to solve those errors